### PR TITLE
Bubble column behavior changes

### DIFF
--- a/Ahorn/entities/bubblePushField.jl
+++ b/Ahorn/entities/bubblePushField.jl
@@ -3,7 +3,7 @@ module YetAnotherHelperBubbleField
 using ..Ahorn, Maple
 
 @mapdef Entity "YetAnotherHelper/BubbleField" BubbleField(x::Integer, y::Integer, width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight,
-	strength::Number=1.0, direction::String="Right", flag::String="bubble_push_field", activationMode::String="Always")
+	strength::Number=1.0, direction::String="Right", flag::String="bubble_push_field", activationMode::String="Always", liftOffOfGround::Bool=false)
 
 const placements = Ahorn.PlacementDict(
 	"Bubble Column (Yet Another Helper)" => Ahorn.EntityPlacement(

--- a/Ahorn/entities/bubblePushField.jl
+++ b/Ahorn/entities/bubblePushField.jl
@@ -3,7 +3,7 @@ module YetAnotherHelperBubbleField
 using ..Ahorn, Maple
 
 @mapdef Entity "YetAnotherHelper/BubbleField" BubbleField(x::Integer, y::Integer, width::Integer=Maple.defaultBlockWidth, height::Integer=Maple.defaultBlockHeight,
-	strength::Number=1.0, direction::String="Right", flag::String="bubble_push_field", activationMode::String="Always", liftOffOfGround::Bool=false)
+	strength::Number=1.0, direction::String="Right", flag::String="bubble_push_field", activationMode::String="Always", liftOffOfGround::Bool=true)
 
 const placements = Ahorn.PlacementDict(
 	"Bubble Column (Yet Another Helper)" => Ahorn.EntityPlacement(

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -10,7 +10,7 @@ placements.entities.YetAnotherHelper/BubbleField.tooltips.strength=The strength 
 placements.entities.YetAnotherHelper/BubbleField.tooltips.direction=The direction the bubbles move.
 placements.entities.YetAnotherHelper/BubbleField.tooltips.activationMode=Determines on which condition the bubble column activates.
 placements.entities.YetAnotherHelper/BubbleField.tooltips.flag=The session flag this bubble column reacts to (when Activation Mode is "only if flag [in]active").
-placements.entities.YetAnotherHelper/BubbleField.tooltips.liftOffOfGround=Whether or not the bubble column should push the player off of the ground. Only has an effect if the bubble column is facing upwards.
+placements.entities.YetAnotherHelper/BubbleField.tooltips.liftOffOfGround=Whether or not the bubble column should push the player away from ground. This includes lifting them off of the floor (if they are standing on one), and pushing them away from walls that they are next to.
 
 # Flag Kill Barrier
 

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -10,6 +10,7 @@ placements.entities.YetAnotherHelper/BubbleField.tooltips.strength=The strength 
 placements.entities.YetAnotherHelper/BubbleField.tooltips.direction=The direction the bubbles move.
 placements.entities.YetAnotherHelper/BubbleField.tooltips.activationMode=Determines on which condition the bubble column activates.
 placements.entities.YetAnotherHelper/BubbleField.tooltips.flag=The session flag this bubble column reacts to (when Activation Mode is "only if flag [in]active").
+placements.entities.YetAnotherHelper/BubbleField.tooltips.liftOffOfGround=Whether or not the bubble column should push the player off of the ground. Only has an effect if the bubble column is facing upwards.
 
 # Flag Kill Barrier
 

--- a/YetAnotherHelper/Entities/BubblePushField.cs
+++ b/YetAnotherHelper/Entities/BubblePushField.cs
@@ -190,6 +190,12 @@ namespace Celeste.Mod.YetAnotherHelper.Entities
         {
             Vector2 windDirection = (Vector2)playerWindDirection.GetValue(player);
 
+            if (player.OnGround() && (player.Ducking)) 
+            {
+                playerWindDirection.SetValue(player, windDirection);
+                return false;
+            }
+
             if (!player.JustRespawned && (float)playerNoWindTimer.GetValue(player) <= 0f && player.InControl && player.StateMachine.State != 4 && player.StateMachine.State != 2 && player.StateMachine.State != 10)
             {
                 if (move.X != 0f && player.StateMachine.State != 1) 
@@ -212,12 +218,7 @@ namespace Celeste.Mod.YetAnotherHelper.Entities
                 }
                 if (move.Y != 0f)
                 {
-                    if (player.OnGround() && (player.Ducking)) 
-                    {
-                        playerWindDirection.SetValue(player, windDirection);
-                        return false;
-                    }
-                    else if (player.OnGround() && Direction == PushDirection.Up && Strength < 1.5f)
+                    if (player.OnGround() && Direction == PushDirection.Up && Strength < 1.5f)
                     {
                         playerWindDirection.SetValue(player, windDirection);
                         return true;

--- a/YetAnotherHelper/Entities/BubblePushField.cs
+++ b/YetAnotherHelper/Entities/BubblePushField.cs
@@ -36,6 +36,8 @@ namespace Celeste.Mod.YetAnotherHelper.Entities
 
         private string flag;
 
+        private bool liftOffOfGround;
+
         private static FieldInfo playerWindTimeout;
 
         private static FieldInfo playerWindDirection;
@@ -51,15 +53,17 @@ namespace Celeste.Mod.YetAnotherHelper.Entities
             data.Float("strength", 1f),
             data.Attr("direction", "right"),
             data.Enum("activationMode", ActivationMode.Always),
-            data.Attr("flag", "bubble_push_field")
+            data.Attr("flag", "bubble_push_field"),
+            data.Bool("liftOffOfGround", false)
             ) { }
 
-        public BubblePushField(Vector2 position, int width, int height, float strength, string direction, ActivationMode activationMode, string flag)
+        public BubblePushField(Vector2 position, int width, int height, float strength, string direction, ActivationMode activationMode, string flag, bool liftOff)
         {
             Position = position;
             Strength = strength;
             this.activationMode = activationMode;
             this.flag = flag;
+            this.liftOffOfGround = liftOff;
 
             Enum.TryParse(direction, out Direction);
 
@@ -216,10 +220,16 @@ namespace Celeste.Mod.YetAnotherHelper.Entities
                         player.MoveH(move.X);
                     }
                 }
+
                 if (move.Y != 0f)
                 {
-                    if (player.OnGround() && Direction == PushDirection.Up && Strength < 1.5f)
+                    if (player.OnGround())
                     {
+                        if (liftOffOfGround)
+                        {   
+                            player.MoveV(move.Y);
+                        }
+
                         playerWindDirection.SetValue(player, windDirection);
                         return true;
                     }

--- a/YetAnotherHelper/Entities/BubblePushField.cs
+++ b/YetAnotherHelper/Entities/BubblePushField.cs
@@ -202,11 +202,11 @@ namespace Celeste.Mod.YetAnotherHelper.Entities
 
             if (!player.JustRespawned && (float)playerNoWindTimer.GetValue(player) <= 0f && player.InControl && player.StateMachine.State != 4 && player.StateMachine.State != 2 && player.StateMachine.State != 10)
             {
-                if (move.X != 0f && player.StateMachine.State != 1) 
+                if (move.X != 0f) 
                 {
                     playerWindTimeout.SetValue(player, 0.2f);
                     windDirection.X = (float)Math.Sign(move.X);
-                    if (!player.CollideCheck<Solid>(player.Position + Vector2.UnitX * (float)(-(float)Math.Sign(move.X)) * 3f))
+                    if (liftOffOfGround || (!player.CollideCheck<Solid>(player.Position + Vector2.UnitX * (float)(-(float)Math.Sign(move.X)) * 3f) && player.StateMachine.State != 1))
                     {
                         if (move.X < 0f)
                         {

--- a/YetAnotherHelper/Entities/SpikeJumpThruController.cs
+++ b/YetAnotherHelper/Entities/SpikeJumpThruController.cs
@@ -10,7 +10,7 @@ using System.Linq;
 namespace Celeste.Mod.YetAnotherHelper.Entities 
 {
     [CustomEntity("YetAnotherHelper/SpikeJumpThruController")]
-    class SpikeJumpThruController : Entity 
+    public class SpikeJumpThruController : Entity 
     {
         private static bool SpikeHooked;
         private static SpikeJumpThruController CurrentController;

--- a/YetAnotherHelper/Module/YetAnotherHelper.cs
+++ b/YetAnotherHelper/Module/YetAnotherHelper.cs
@@ -27,6 +27,7 @@ namespace Celeste.Mod.YetAnotherHelper.Module
             RemoveLightSourcesTrigger.Load();
             StickyJellyfish.Load();
             SpikeJumpThruController.Load();
+            BubblePushField.Load();
         }
 
         public override void Initialize()

--- a/YetAnotherHelper/Triggers/FlagKillBox.cs
+++ b/YetAnotherHelper/Triggers/FlagKillBox.cs
@@ -5,7 +5,7 @@ using Monocle;
 namespace Celeste.Mod.YetAnotherHelper.Triggers
 {
     [CustomEntity("YetAnotherHelper/FlagKillBox")]
-    class FlagKillBox : Trigger
+    public class FlagKillBox : Trigger
     {
         public bool KillBoxActive { get; private set; }
 

--- a/YetAnotherHelper/Triggers/LightningStrikeTrigger.cs
+++ b/YetAnotherHelper/Triggers/LightningStrikeTrigger.cs
@@ -8,7 +8,7 @@ using System;
 namespace Celeste.Mod.YetAnotherHelper.Triggers
 {
     [CustomEntity("YetAnotherHelper/LightningStrikeTrigger")]
-    class LightningStrikeTrigger : Trigger
+    public class LightningStrikeTrigger : Trigger
     {
         public bool Activated { get; private set; }
 

--- a/YetAnotherHelper/Triggers/SpawnJellyTrigger.cs
+++ b/YetAnotherHelper/Triggers/SpawnJellyTrigger.cs
@@ -4,7 +4,7 @@ using Microsoft.Xna.Framework;
 namespace Celeste.Mod.YetAnotherHelper.Triggers
 {
     [CustomEntity("YetAnotherHelper/SpawnJellyTrigger")]
-    class SpawnJellyTrigger : Trigger
+    public class SpawnJellyTrigger : Trigger
     {
         public bool OnlyOnce { get; private set; }
 


### PR DESCRIPTION
Bubble columns have been adjusted to behave differently when moving players. The changes are as follows:
  - If a player is on the ground and the mapmaker has set the bubble column to lift them off the ground, they will be lifted off of the ground.
  - If a player is crouching on the ground within a bubble column, they will not be moved, as was the case before. *However,* crouching now also resets the "charging" period in which the bubble column does not push the player at full force. This means that upon uncrouching, players will not immediately begin moving at full speed and instead will experience the gradual build up in speed as if they had just entered the bubble column.

~~It may also be worth considering to add a toggle for legacy behavior in case anyone prefers it in their map?~~ 
~~Legacy behavior is now defaulted to.~~
The Ahorn plugin defaults to new behavior but old maps still have the old behavior.